### PR TITLE
Remove unused dependencies from threadtear:gui.

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,8 +3,7 @@ plugins {
 }
 
 fun DependencyHandlerScope.externalLib(libraryName: String) {
-    compileOnly(files("${rootProject.rootDir}/libs/$libraryName.jar"))
-    runtimeOnly(files("${rootProject.rootDir}/libs/$libraryName.jar"))
+    implementation(files("${rootProject.rootDir}/libs/$libraryName.jar"))
 }
 
 dependencies {
@@ -13,8 +12,8 @@ dependencies {
     implementation("org.apache.commons:commons-configuration2")
     implementation("commons-beanutils:commons-beanutils")
 
+    api("org.ow2.asm:asm-tree")
     implementation("org.ow2.asm:asm")
-    implementation("org.ow2.asm:asm-tree")
     implementation("org.ow2.asm:asm-analysis")
     implementation("org.ow2.asm:asm-util")
 

--- a/core/src/main/java/me/nov/threadtear/decompiler/CFRBridge.java
+++ b/core/src/main/java/me/nov/threadtear/decompiler/CFRBridge.java
@@ -7,6 +7,7 @@ import java.util.*;
 import org.apache.commons.io.IOUtils;
 import org.benf.cfr.reader.api.*;
 import org.benf.cfr.reader.bytecode.analysis.parse.utils.Pair;
+import org.benf.cfr.reader.util.CfrVersionInfo;
 import org.objectweb.asm.tree.ClassNode;
 
 import me.nov.threadtear.io.Conversion;
@@ -96,5 +97,23 @@ public class CFRBridge implements IDecompilerBridge {
       result = "No CFR output received";
     }
     return result;
+  }
+
+  public static class CFRDecompilerInfo extends DecompilerInfo<CFRBridge> {
+
+    @Override
+    public String getName() {
+      return "CFR";
+    }
+
+    @Override
+    public String getVersionInfo() {
+      return CfrVersionInfo.VERSION;
+    }
+
+    @Override
+    public CFRBridge createDecompilerBridge() {
+      return new CFRBridge();
+    }
   }
 }

--- a/core/src/main/java/me/nov/threadtear/decompiler/DecompilerInfo.java
+++ b/core/src/main/java/me/nov/threadtear/decompiler/DecompilerInfo.java
@@ -1,0 +1,26 @@
+package me.nov.threadtear.decompiler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class DecompilerInfo<T extends IDecompilerBridge> {
+
+  public abstract String getName();
+
+  public abstract String getVersionInfo();
+
+  public abstract T createDecompilerBridge();
+
+  @Override
+  public String toString() {
+    return getName() + " " + getVersionInfo();
+  }
+
+  public static List<DecompilerInfo<?>> getDecompilerInfos() {
+    List<DecompilerInfo<?>> list = new ArrayList<>(3);
+    list.add(new CFRBridge.CFRDecompilerInfo());
+    list.add(new FernflowerBridge.FernflowerDecompilerInfo());
+    list.add(new KrakatauBridge.KrakatauDecompilerInfo());
+    return list;
+  }
+}

--- a/core/src/main/java/me/nov/threadtear/decompiler/FernflowerBridge.java
+++ b/core/src/main/java/me/nov/threadtear/decompiler/FernflowerBridge.java
@@ -112,4 +112,21 @@ public class FernflowerBridge implements IDecompilerBridge, IBytecodeProvider, I
   public void closeArchive(String path, String archiveName) {
   }
 
+  public static class FernflowerDecompilerInfo extends DecompilerInfo<FernflowerBridge> {
+
+    @Override
+    public String getName() {
+      return "Fernflower";
+    }
+
+    @Override
+    public String getVersionInfo() {
+      return "15-08-20";
+    }
+
+    @Override
+    public FernflowerBridge createDecompilerBridge() {
+      return new FernflowerBridge();
+    }
+  }
 }

--- a/core/src/main/java/me/nov/threadtear/decompiler/IDecompilerBridge.java
+++ b/core/src/main/java/me/nov/threadtear/decompiler/IDecompilerBridge.java
@@ -3,6 +3,7 @@ package me.nov.threadtear.decompiler;
 import java.io.File;
 
 public interface IDecompilerBridge {
+
   void setAggressive(boolean aggressive);
 
   String decompile(File archive, String name, byte[] bytes);

--- a/gui/build.gradle.kts
+++ b/gui/build.gradle.kts
@@ -3,33 +3,19 @@ plugins {
     id("com.github.johnrengelman.shadow")
 }
 
-fun DependencyHandlerScope.externalLib(libraryName: String) {
-    compileOnly(files("${rootProject.rootDir}/libs/$libraryName.jar"))
-    runtimeOnly(files("${rootProject.rootDir}/libs/$libraryName.jar"))
-}
-
 dependencies {
     implementation(project(":threadtear-core"))
-    implementation("commons-io:commons-io")
-
-    implementation("org.apache.commons:commons-configuration2")
-    implementation("commons-beanutils:commons-beanutils")
 
     implementation("com.github.weisj:darklaf-core") { isChanging = true }
     implementation("com.github.weisj:darklaf-theme") { isChanging = true }
     implementation("com.github.weisj:darklaf-property-loader") { isChanging = true }
 
-    implementation("org.ow2.asm:asm")
-    implementation("org.ow2.asm:asm-tree")
-    implementation("org.ow2.asm:asm-analysis")
-    implementation("org.ow2.asm:asm-util")
-
-    implementation("com.github.leibnitz27:cfr") { isChanging = true }
     implementation("com.fifesoft:rsyntaxtextarea")
     implementation("com.github.jgraph:jgraphx")
     implementation("ch.qos.logback:logback-classic")
 
-    externalLib("fernflower-15-05-20")
+    implementation("commons-io:commons-io")
+    implementation("org.apache.commons:commons-configuration2")
 }
 
 tasks.shadowJar {


### PR DESCRIPTION
Declared exposed dependency of threadtear:core as api (transitive dependency).
Decoupled version information of decompilers from gui project to make it easier to add new decompilers.