### PR TITLE
Replace ImageUtil#createFrameIcon with IconLoader#createFrameIcon

### DIFF
--- a/gui/src/main/java/me/nov/threadtear/swing/SwingUtils.java
+++ b/gui/src/main/java/me/nov/threadtear/swing/SwingUtils.java
@@ -2,7 +2,6 @@ package me.nov.threadtear.swing;
 
 import com.github.weisj.darklaf.components.OverlayScrollPane;
 import com.github.weisj.darklaf.components.border.DarkBorders;
-import com.github.weisj.darklaf.graphics.ImageUtil;
 import com.github.weisj.darklaf.icons.IconLoader;
 import me.nov.threadtear.Threadtear;
 import me.nov.threadtear.swing.textarea.DecompilerTextArea;
@@ -166,7 +165,7 @@ public class SwingUtils {
   }
 
   public static Image iconToFrameImage(Icon icon, Window window) {
-    return ImageUtil.createFrameIcon(icon, window);
+    return IconLoader.createFrameIcon(icon, window);
   }
 
   public static Icon getIcon(String path) {


### PR DESCRIPTION
With the release version of darklaf `2.3.0` `ImageUtil#createFrameIcon ` was moved to `IconLoader#createFrameIcon `.