### PR TITLE
Fix NPE w/ native methods in TryCatchObfuscationRemover

### DIFF
--- a/core/src/main/java/me/nov/threadtear/execution/generic/TryCatchObfuscationRemover.java
+++ b/core/src/main/java/me/nov/threadtear/execution/generic/TryCatchObfuscationRemover.java
@@ -70,6 +70,11 @@ public class TryCatchObfuscationRemover extends Execution {
           logger.warning("Getter {} not found, possibly library", min.owner + "." + min.name + min.desc);
         return false;
       }
+      if ((getter.access & ACC_NATIVE) != 0) {
+        if (verbose)
+          logger.warning("Getter {} is a native method, skipping", min.owner + "." + min.name + min.desc);
+        return false;
+      }
       AbstractInsnNode getterFirst = getter.instructions.getFirst();
       while (getterFirst.getOpcode() == -1) {
         getterFirst = ain.getNext();


### PR DESCRIPTION
TryCatchObfuscationRemover.isFake does not account for native methods being invoked, which can cause a NPE due to them not having any instructions.

There probably is other special cases like this related to this pass, so we should probably check this with other 'special' method types. (abstract methods?)